### PR TITLE
Add GitHub Actions to publish to maven central repository on tag creation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: Publish to Maven Central Repository
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: set up Gradle properties
+        shell: bash
+        env:
+          PUBLICATION_PROPERTIES: ${{ secrets.PUBLICATION_PROPERTIES }}
+        run: echo "$PUBLICATION_PROPERTIES" >> gradle.properties
+
+      - name: publish
+        run: ./gradlew :core:clean :core:publishAndReleaseToMavenCentral --no-configuration-cache


### PR DESCRIPTION
# What

Add GitHub Actions to publish to maven central repository on tag creation.
This mean release created.

closes #28 thanks to this and #29.

# How

## credentials

Sonatype credentials are stored to `PUBLICATION_PROPERTIES` secret as gradle properties format.
Publish task references it after write it to `/gradle.properties` step/

# Notes

N/A
