### PR TITLE
Add support for `AppConfigDataClient` in AWS SDK

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     compileOnly(libs.openfeature)
     implementation(libs.aws.appconfigdata)
     implementation(libs.jackson.databind)
+    implementation(libs.jakarta.annotation.api)
 
     // spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0")
     // spotbugs("com.github.spotbugs:spotbugs:4.8.0")

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/model/Credential.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/model/Credential.java
@@ -1,0 +1,40 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A class to mask secret string to avoid it appeared in logging or something.
+ * This works completely exactly except {@code toString} method. For example, comparison or equality.
+ */
+@Getter
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public final class Credential implements Comparable<Credential> {
+
+    @NotNull
+    @NonNull
+    private final String rawValue;
+
+    @Override
+    public String toString() {
+        return "Masked credentials(***)";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Credential credential) {
+            return rawValue.equals(credential.rawValue);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int compareTo(@NotNull Credential o) {
+        return rawValue.compareTo(o.rawValue);
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AbstractAwsAppConfigProxy.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AbstractAwsAppConfigProxy.java
@@ -1,9 +1,7 @@
 package io.github.lavenderses.aws_app_config_openfeature_provider.proxy;
 
-import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigProxyConfig;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.NonNull;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,10 +20,6 @@ import static java.util.Objects.isNull;
 public abstract class AbstractAwsAppConfigProxy implements AwsAppConfigProxy {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractAwsAppConfigProxy.class);
-
-    @NotNull
-    @NonNull
-    protected final AwsAppConfigProxyConfig awsAppConfigProxyConfig;
 
     /**
      * @param key feature flag key in OpenFeature world

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AwsAppConfigProxy.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AwsAppConfigProxy.java
@@ -19,8 +19,7 @@ import org.jetbrains.annotations.Nullable;
  * To hide this difference, this interface is introduced (to connect whatever kind of the AWS AppConfig instance from
  * Provider implementation).
  */
-@FunctionalInterface
-public interface AwsAppConfigProxy {
+public interface AwsAppConfigProxy extends AutoCloseable {
 
     /**
      * Get the feature flag value as JSON schema (see {@link AppConfigValue} for the schema).<br/>

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AwsAppConfigProxyBuilder.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AwsAppConfigProxyBuilder.java
@@ -2,7 +2,9 @@ package io.github.lavenderses.aws_app_config_openfeature_provider.proxy;
 
 import io.github.lavenderses.aws_app_config_openfeature_provider.AwsAppConfigClientOptions;
 import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.agent.AwsAppConfigAgentProxy;
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client.AwsAppConfigDataClientProxy;
 import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigAgentProxyConfig;
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigDataClientProxyConfig;
 import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigProxyConfig;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,8 +18,13 @@ public final class AwsAppConfigProxyBuilder {
 
         if (config instanceof AwsAppConfigAgentProxyConfig) {
             return new AwsAppConfigAgentProxy(
-                /* optionsi = */ options,
+                /* option = */ options,
                 /* config = */ (AwsAppConfigAgentProxyConfig) config
+            );
+        } else if (config instanceof AwsAppConfigDataClientProxyConfig) {
+            return new AwsAppConfigDataClientProxy(
+                /* options = */ options,
+                /* config = */ (AwsAppConfigDataClientProxyConfig) config
             );
         } else {
             throw new IllegalArgumentException(String.format("unknown type of config: %s", config));

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/agent/AwsAppConfigAgentProxy.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/agent/AwsAppConfigAgentProxy.java
@@ -51,9 +51,7 @@ public final class AwsAppConfigAgentProxy extends AbstractAwsAppConfigProxy {
         @NotNull final HttpClient httpClient,
         @NotNull final HttpResponse.BodyHandler<String> handler
         ) {
-        super(
-            /* awsAppConfigProxyConfig = */ requireNonNull(awsAppConfigProxyConfig, "awsAppConfigProxyConfig")
-        );
+        super();
 
         this.options = requireNonNull(options, "aws");
         config = requireNonNull(awsAppConfigProxyConfig, "awsAppConfigProxyConfig");
@@ -65,14 +63,17 @@ public final class AwsAppConfigAgentProxy extends AbstractAwsAppConfigProxy {
         @NotNull final AwsAppConfigClientOptions options,
         @NotNull final AwsAppConfigAgentProxyConfig awsAppConfigProxyConfig
     ) {
-        super(
-            /* awsAppConfigProxyConfig = */ requireNonNull(awsAppConfigProxyConfig, "awsAppConfigProxyConfig")
-        );
+        super();
 
         this.options = requireNonNull(options, "aws");
-        config = awsAppConfigProxyConfig;
+        config = requireNonNull(awsAppConfigProxyConfig, "awsAppConfigProxyConfig");
         httpClient = setupHttpClient();
         handler = HttpResponse.BodyHandlers.ofString();
+    }
+
+    @Override
+    public void close() {
+        // nothing to close
     }
 
     /**

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/AwsAppConfigDataClientProxy.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/AwsAppConfigDataClientProxy.java
@@ -1,0 +1,85 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.lavenderses.aws_app_config_openfeature_provider.AwsAppConfigClientOptions;
+import io.github.lavenderses.aws_app_config_openfeature_provider.app_config_model.AppConfigValue;
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.AbstractAwsAppConfigProxy;
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigDataClientProxyConfig;
+import jakarta.annotation.PreDestroy;
+import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Provider implementation proxy for accessing AWS AppConfig instance via AWS AppConfig client from SDK.
+ * <br/>
+ * You can use this with the client instance you prepared. Or just pass the configuration class, then this class creates
+ * and manages it.
+ */
+public final class AwsAppConfigDataClientProxy extends AbstractAwsAppConfigProxy {
+
+    private final CachedFeatureFlagManager cachedFeatureFlagManager;
+
+    @VisibleForTesting
+    AwsAppConfigDataClientProxy(
+        @NotNull final CachedFeatureFlagManager cachedFeatureFlagManager
+    ) {
+        super();
+
+        this.cachedFeatureFlagManager = requireNonNull(cachedFeatureFlagManager, "cachedFeatureFlagManager");
+    }
+
+    /**
+     * Constructor for configuring {@link AppConfigDataClient} with your own configuration.
+     * <br/>
+     * When you use this constructor, this provider implementation library is responsible for closing
+     * {@link AppConfigDataClient} resource. You don't have to worry about.
+     *
+     * @param config a configuration to {@link AppConfigDataClient}
+     */
+    public AwsAppConfigDataClientProxy(
+        @NotNull final AwsAppConfigClientOptions options,
+        @NotNull final AwsAppConfigDataClientProxyConfig config
+    ) {
+        super();
+
+        cachedFeatureFlagManager = new CachedFeatureFlagManager(
+            /* options = */ options,
+            /* config = */ config,
+            /* startSession = */ true
+        );
+    }
+
+    @PreDestroy
+    @Override
+    public void close() throws Exception {
+        cachedFeatureFlagManager.close();
+    }
+
+    /**
+     * Get the feature flag value as JSON schema (see {@link AppConfigValue} for the schema).<br/>
+     * Note that return value is not validated, this is just raw value from AWS AppConfig.
+     *
+     * @param key feature flag key
+     * @return JSON schema response from AWS AppConfigInstance
+     */
+    @Language("json")
+    @Nullable
+    @Override
+    public String getRawFlagObject(@NotNull final String key) {
+        final JsonNode featureFlagJsonValue = cachedFeatureFlagManager.getCachedFeatureFlagByKeyFrom(
+            /* key = */ requireNonNull(key, "key")
+        );
+
+        if (isNull(featureFlagJsonValue)) {
+            return null;
+        } else {
+            return featureFlagJsonValue.toString();
+        }
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagManager.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagManager.java
@@ -1,0 +1,274 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lavenderses.aws_app_config_openfeature_provider.AwsAppConfigClientOptions;
+import io.github.lavenderses.aws_app_config_openfeature_provider.model.Credential;
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigDataClientProxyConfig;
+import io.github.lavenderses.aws_app_config_openfeature_provider.task.ScheduledTask;
+import io.github.lavenderses.aws_app_config_openfeature_provider.task.ScheduledTaskExecutor;
+import io.github.lavenderses.aws_app_config_openfeature_provider.task.ScheduledTaskOption;
+import io.github.lavenderses.aws_app_config_openfeature_provider.utils.ObjectMapperBuilder;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClientBuilder;
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest;
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse;
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest;
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionResponse;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static java.util.Objects.nonNull;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Management class of on-memory-cached feature flag.
+ * Once this class is instantiated, this starts infinite scheduled task which updates feature flag cache and access
+ * token for AWS AppConfig server.
+ */
+final class CachedFeatureFlagManager implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(AwsAppConfigDataClientProxy.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperBuilder.build();
+
+    /**
+     * A task to be executed infinitely to keep session and update token for AWS AppConfig.
+     */
+    @VisibleForTesting
+    final class CachedFeatureFlagUpdateTask implements ScheduledTask {
+
+        @Override
+        public void run() {
+            // TODO: error handling
+            log.info("Start updating AWS AppConfig cache");
+            final FeatureFlagCache oldCache = responseCache.get();
+            final FeatureFlagCache newCache;
+
+            try {
+                // get latest feature flag from AWS AppConfig
+                final GetLatestConfigurationResponse response = getLatestConfigurationResponse(
+                    /* credential = */ oldCache.getToken()
+                );
+
+                // update token and feature flag
+                newCache = newCache(
+                    /* oldCache = */ oldCache,
+                    /* response = */ response
+                );
+            } catch (final Exception e) {
+                log.error("Failed to update feature flag cache", e);
+                return;
+            }
+
+            if (nonNull(newCache)) {
+                responseCache.set(newCache);
+                log.info("Updated AWS AppConfig cache: {}", newCache.getFlags());
+            }
+        }
+
+        @VisibleForTesting
+        GetLatestConfigurationResponse getLatestConfigurationResponse(
+            @NotNull final Credential token
+        ) {
+            final GetLatestConfigurationRequest request = GetLatestConfigurationRequest.builder()
+                .configurationToken(token.getRawValue())
+                .build();
+
+            return client.getLatestConfiguration(
+                /* startConfigurationSessionRequest = */ request
+            );
+        }
+
+        /**
+         * Extracts new value to be cached ({@link FeatureFlagCache} from response from AWS AppConfig.
+         */
+        @Nullable
+        @VisibleForTesting
+        FeatureFlagCache newCache(
+            @NotNull final FeatureFlagCache oldCache,
+            @NotNull final GetLatestConfigurationResponse response
+        ) {
+            // Update cache for the next configuration poll
+            final Credential pollingToken = Credential.builder()
+                .rawValue(response.nextPollConfigurationToken())
+                .build();
+
+            final String jsonResponse = response.configuration().asUtf8String();
+            if (jsonResponse.isEmpty()) {
+                log.info("Response from AWS AppConfig is empty. Flag is latest, so skip updating cache.");
+                log.debug("See more for https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/appconfigdata/AppConfigDataClient.html");
+
+                // just update token
+                return oldCache.toBuilder()
+                    .token(pollingToken)
+                    .build();
+            }
+
+            final JsonNode value;
+            try {
+                value = OBJECT_MAPPER.readTree(jsonResponse);
+            } catch (final JsonProcessingException e) {
+                log.error(
+                    "Unexpected response from AWS AppConfig: {}. Skip updating cache.",
+                    response.configuration(),
+                    e
+                );
+                // just update token
+                return oldCache.toBuilder()
+                    .token(pollingToken)
+                    .build();
+            }
+
+            final Map<String, JsonNode> newFeatureFlags = new HashMap<>();
+            for (final Iterator<Map.Entry<String, JsonNode>> it = value.fields(); it.hasNext(); ) {
+                final Map.Entry<String, JsonNode> entry = it.next();
+                newFeatureFlags.put(entry.getKey(), entry.getValue());
+            }
+
+            // update token and feature flag
+            return oldCache.toBuilder()
+                .token(pollingToken)
+                .flags(newFeatureFlags)
+                .build();
+        }
+    }
+
+    @NotNull
+    private final AwsAppConfigClientOptions options;
+
+    @NotNull
+    private final AppConfigDataClient client;
+
+    private final AtomicReference<FeatureFlagCache> responseCache = new AtomicReference<>(FeatureFlagCache.EMPTY);
+
+    private final ScheduledTaskExecutor scheduledTaskExecutor;
+
+    private final CachedFeatureFlagUpdateTask task = new CachedFeatureFlagUpdateTask();
+
+    /**
+     * Whether to start AWS AppConfig session.
+     * This will be false if it is a testing phase.
+     */
+    private final boolean startSession;
+
+    @VisibleForTesting
+    CachedFeatureFlagManager(
+        @NotNull final AwsAppConfigClientOptions options,
+        @NotNull final AppConfigDataClient client,
+        @NotNull final ScheduledTaskExecutor scheduledTaskExecutor
+    ) {
+        this.options = requireNonNull(options, "options");
+        this.client = requireNonNull(client, "client");
+        this.scheduledTaskExecutor = requireNonNull(scheduledTaskExecutor, "scheduledTaskExecutor");
+        startSession = false;
+    }
+
+    CachedFeatureFlagManager(
+        @NotNull final AwsAppConfigClientOptions options,
+        @NotNull final AwsAppConfigDataClientProxyConfig config,
+        final boolean startSession
+    ) {
+        this.options = requireNonNull(options, "options");
+        this.startSession = startSession;
+
+        final AppConfigDataClientBuilder builder = AppConfigDataClient.builder()
+            .region(config.getRegion());
+        final Consumer<AppConfigDataClientBuilder> configure =config.getConfigure();
+        if (nonNull(configure)) {
+            configure.accept(builder);
+        }
+        this.client = builder.build();
+
+        scheduledTaskExecutor = new ScheduledTaskExecutor(
+            /* option = */ ScheduledTaskOption.builder()
+                .delay(config.getPollingDelay())
+                .build()
+        );
+    }
+
+    /**
+     * Initiates session for AWS AppConfig.
+     * And also starts infinite task which updates local cached feature flags and access token to AWS AppConfig.
+     */
+    @PostConstruct
+    void startSession() {
+        if (!startSession) {
+            return;
+        }
+
+        initSession();
+
+        // start scheduled task to update token
+        scheduledTaskExecutor.start(
+            /* task = */ task
+        );
+    }
+
+    @PreDestroy
+    @Override
+    public void close() throws Exception {
+        scheduledTaskExecutor.close();
+        client.close();
+    }
+
+    @VisibleForTesting
+    void initSession() {
+        log.info("Start initializing AWS AppConfig token");
+
+        // TODO: error handling
+        final StartConfigurationSessionRequest request = StartConfigurationSessionRequest.builder()
+            .applicationIdentifier(options.getApplicationName())
+            .environmentIdentifier(options.getEnvironmentName())
+            .configurationProfileIdentifier(options.getProfile())
+            .build();
+
+        final StartConfigurationSessionResponse response = client.startConfigurationSession(
+            /* startConfigurationSessionRequest = */ request
+        );
+        final String initToken = response.initialConfigurationToken();
+        responseCache.getAndUpdate(
+            (oldFeatureFlagCache) -> oldFeatureFlagCache
+                .toBuilder()
+                .token(
+                    Credential.builder()
+                        .rawValue(initToken)
+                        .build()
+                )
+                .build()
+        );
+
+        log.info("Initialized AWS AppConfig token");
+    }
+
+    /**
+     * Gets feature flag value with key {@param key}.
+     * The return value will be null if the feature flag associated with {@param key} does not found.
+     */
+    @Nullable
+    JsonNode getCachedFeatureFlagByKeyFrom(
+        @NotNull final String key
+    ) {
+        requireNonNull(key, "Key");
+
+        final FeatureFlagCache cache = responseCache.get();
+        return cache.getFlags().get(key);
+    }
+
+    @VisibleForTesting
+    AtomicReference<FeatureFlagCache> getResponseCache() {
+        return responseCache;
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/FeatureFlagCache.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/FeatureFlagCache.java
@@ -1,0 +1,35 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.lavenderses.aws_app_config_openfeature_provider.model.Credential;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@Builder(toBuilder = true)
+@ToString(callSuper = true)
+final class FeatureFlagCache {
+
+    static final FeatureFlagCache EMPTY = FeatureFlagCache.builder()
+        .token(
+            Credential.builder()
+                .rawValue("")
+                .build()
+        )
+        .flags(new HashMap<>())
+        .build();
+
+    @NotNull
+    @NonNull
+    private final Credential token;
+
+    @NotNull
+    @NonNull
+    private final Map<String, JsonNode> flags;
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/config/AwsAppConfigDataClientProxyConfig.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/config/AwsAppConfigDataClientProxyConfig.java
@@ -1,0 +1,41 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClientBuilder;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+/**
+ * Configuration for accessing AWS AppConfig instance via AWS AppConfig data client from AWS SDK.
+ * <a href="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/appconfigdata/AppConfigDataClient.html>
+ * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/appconfigdata/AppConfigDataClient.html</a>
+ * By using this configuration, this Provider implementation connect to the Agent via the client instance.
+ */
+@Data
+@Builder(toBuilder = true)
+@ToString(callSuper = true)
+public final class AwsAppConfigDataClientProxyConfig implements AwsAppConfigProxyConfig {
+
+    @NotNull
+    @NonNull
+    private final Region region;
+
+    @NotNull
+    @NonNull
+    private final Duration pollingDelay;
+
+    /**
+     * An {@link AppConfigDataClientBuilder} configuration method. You can configure any options it supports.
+     * If this is null, no more configuration will be applied to it. Just calls {@link AppConfigDataClient#create()}.
+     */
+    @Nullable
+    private final Consumer<AppConfigDataClientBuilder> configure;
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTask.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTask.java
@@ -1,0 +1,12 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.task;
+
+/**
+ * An interface for the task which should be executed infinitely.
+ * To execute it, pass this task to {@link ScheduledTaskExecutor#start(ScheduledTask)}.
+ * <br/>
+ * Note that this task should execute single processing task, no need to loop infinitely.
+ */
+public interface ScheduledTask {
+
+    void run();
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTaskExecutor.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTaskExecutor.java
@@ -1,0 +1,85 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.task;
+
+import jakarta.annotation.PreDestroy;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Internal library to execute infinite task (which implements {@link ScheduledTask}).
+ * This class manages followings.
+ * <ul>
+ *     <li>Task execution interval</li>
+ *     <li>Task execution resources (like thread)</li>
+ *     <li>Safe resource close</li>
+ * </ul>
+ */
+public final class ScheduledTaskExecutor implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(ScheduledTaskExecutor.class);
+    private static final long TERMINATION_WAIT_SECOND = 60 * 5;
+
+    @NotNull
+    private final ScheduledExecutorService executorService;
+
+    @NotNull
+    private final ScheduledTaskOption option;
+
+    @VisibleForTesting
+    ScheduledTaskExecutor(
+        @NotNull final ScheduledExecutorService executorService,
+        @NotNull final ScheduledTaskOption option
+    ) {
+        this.executorService = requireNonNull(executorService, "executorService");
+        this.option = requireNonNull(option, "scheduledTaskOption");
+    }
+
+    public ScheduledTaskExecutor(
+        @NotNull final ScheduledTaskOption option
+    ) {
+        executorService = Executors.newScheduledThreadPool(1);
+
+        this.option = requireNonNull(option, "scheduledTaskOption");
+    }
+
+    public void start(
+        @NotNull final ScheduledTask execution
+    ) {
+        executorService.scheduleWithFixedDelay(
+            /* command = */ execution::run,
+            /* initialDelay = */ 0,
+            /* delay = */ option.getDelay().getSeconds(),
+            /* unit = */ TimeUnit.SECONDS
+        );
+    }
+
+    @PreDestroy
+    @Override
+    public void close() throws InterruptedException {
+        log.info("Start termination of cache update scheduled task for {} second", TERMINATION_WAIT_SECOND);
+        executorService.shutdown();
+
+        final boolean terminated = executorService.awaitTermination(
+            /* timeout = */ TERMINATION_WAIT_SECOND,
+            /* unit = */ TimeUnit.SECONDS
+        );
+
+        if (terminated) {
+            log.info("Terminated of cache update scheduled task");
+        } else {
+            log.error(
+                "Timed out {} second for termination of cache update scheduled task. Start force termination",
+                TERMINATION_WAIT_SECOND
+            );
+
+            executorService.shutdownNow();
+        }
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTaskOption.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTaskOption.java
@@ -1,0 +1,29 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.task;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * An options to determine the behavior of {@link ScheduledTaskExecutor}.
+ */
+@Data
+@Builder(toBuilder = true)
+@ToString(callSuper = true)
+public final class ScheduledTaskOption {
+
+    public static final ScheduledTaskOption EMPTY_OPTION = ScheduledTaskOption.builder()
+        .delay(Duration.ZERO)
+        .build();
+
+    /**
+     * Fixed delay of the task({@link ScheduledTask}) interval.
+     */
+    @NotNull
+    @NonNull
+    private final Duration delay;
+}

--- a/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AbstractAwsAppConfigProxyTest.kt
+++ b/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/AbstractAwsAppConfigProxyTest.kt
@@ -2,7 +2,6 @@ package io.github.lavenderses.aws_app_config_openfeature_provider.proxy
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigProxyConfig
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
@@ -12,9 +11,11 @@ import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfiguratio
 
 class AbstractAwsAppConfigProxyTest {
 
-    private val abstractAwsAppConfigProxy = object : AbstractAwsAppConfigProxy(
-        /* awsAppConfigProxyConfig = */ object : AwsAppConfigProxyConfig {},
-    ) {
+    private val abstractAwsAppConfigProxy = object : AbstractAwsAppConfigProxy() {
+        override fun close() {
+            TODO("Not yet implemented")
+        }
+
         // mocks
         override fun getRawFlagObject(key: String): String? {
             TODO("Not yet implemented")

--- a/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/AwsAppConfigDataClientProxyTest.kt
+++ b/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/AwsAppConfigDataClientProxyTest.kt
@@ -1,0 +1,84 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.github.lavenderses.aws_app_config_openfeature_provider.utils.ObjectMapperBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations.openMocks
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+
+class AwsAppConfigDataClientProxyTest {
+
+    companion object {
+        private val OBJECT_MAPPER = ObjectMapperBuilder.build()
+    }
+
+    private lateinit var awsAppConfigDataClientProxy: AwsAppConfigDataClientProxy
+
+    @Mock
+    private lateinit var cachedFeatureFlagManager: CachedFeatureFlagManager
+
+    private lateinit var close: AutoCloseable
+
+    @BeforeEach
+    fun setup() {
+        close = openMocks(this)
+
+        awsAppConfigDataClientProxy = AwsAppConfigDataClientProxy(
+            /* cachedFeatureFlagManager = */ cachedFeatureFlagManager,
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        close.close()
+    }
+
+    @Test
+    fun getRawFlagObject() {
+        // prepare
+        val key = "key"
+        val jsonNode = OBJECT_MAPPER.createObjectNode().apply {
+            put("foo", "bar")
+        }
+        val expected = // language=json
+            """{"foo":"bar"}"""
+
+        doReturn(jsonNode)
+            .whenever(cachedFeatureFlagManager)
+            .getCachedFeatureFlagByKeyFrom(
+                /* key = */ key,
+            )
+
+        // do & verify
+        assertThat(
+            awsAppConfigDataClientProxy.getRawFlagObject(
+                /* key = */ key,
+            ),
+        ).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getRawFlagObject when key not found`() {
+        // prepare
+        val key = "key"
+        val expected = null
+
+        doReturn(null)
+            .whenever(cachedFeatureFlagManager)
+            .getCachedFeatureFlagByKeyFrom(
+                /* key = */ key,
+            )
+
+        // do & verify
+        assertThat(
+            awsAppConfigDataClientProxy.getRawFlagObject(
+                /* key = */ key,
+            ),
+        ).isEqualTo(expected)
+    }
+}

--- a/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagManagerTest.kt
+++ b/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagManagerTest.kt
@@ -1,0 +1,83 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.github.lavenderses.aws_app_config_openfeature_provider.AwsAppConfigClientOptions
+import io.github.lavenderses.aws_app_config_openfeature_provider.model.Credential
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigDataClientProxyConfig
+import io.github.lavenderses.aws_app_config_openfeature_provider.task.ScheduledTaskExecutor
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Spy
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionResponse
+import java.time.Duration
+
+@ExtendWith(MockitoExtension::class)
+class CachedFeatureFlagManagerTest {
+
+    @InjectMocks
+    private lateinit var cachedFeatureFlagManager: CachedFeatureFlagManager
+
+    @Spy
+    private val awsAppConfigClientOptions = AwsAppConfigClientOptions.builder()
+        .applicationName("app")
+        .environmentName("env")
+        .profile("profile")
+        .awsAppConfigProxyConfig(
+            AwsAppConfigDataClientProxyConfig.builder()
+                .region(Region.AP_NORTHEAST_1)
+                .pollingDelay(Duration.ZERO)
+                .build(),
+        )
+        .build()
+
+    @Mock
+    private lateinit var appConfigDataClient: AppConfigDataClient
+
+    @Mock
+    private lateinit var scheduledTaskExecutor: ScheduledTaskExecutor
+
+    @Test
+    fun initSession() {
+        // prepare
+        val request = StartConfigurationSessionRequest.builder()
+            .applicationIdentifier("app")
+            .environmentIdentifier("env")
+            .configurationProfileIdentifier("profile")
+            .build()
+        val token = "token"
+        val response = mock<StartConfigurationSessionResponse> {
+            on { initialConfigurationToken() } doReturn token
+        }
+        val expected = FeatureFlagCache.builder()
+            .token(
+                Credential.builder()
+                    .rawValue(token)
+                    .build(),
+            )
+            .flags(emptyMap())
+            .build()
+
+        doReturn(response)
+            .whenever(appConfigDataClient)
+            .startConfigurationSession(
+                /* startConfigurationSessionRequest = */ request,
+            )
+
+        // do
+        cachedFeatureFlagManager.initSession()
+
+        // verify
+        val responseCache = cachedFeatureFlagManager.responseCache
+        assertThat(responseCache.get()).isEqualTo(expected)
+    }
+}

--- a/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagUpdateTaskTest.kt
+++ b/core/src/test/kotlin/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagUpdateTaskTest.kt
@@ -1,0 +1,232 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.github.lavenderses.aws_app_config_openfeature_provider.AwsAppConfigClientOptions
+import io.github.lavenderses.aws_app_config_openfeature_provider.model.Credential
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.appconfig_data_client.CachedFeatureFlagManager.CachedFeatureFlagUpdateTask
+import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.config.AwsAppConfigDataClientProxyConfig
+import io.github.lavenderses.aws_app_config_openfeature_provider.task.ScheduledTaskExecutor
+import io.github.lavenderses.aws_app_config_openfeature_provider.utils.ObjectMapperBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Spy
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse
+import java.time.Duration
+
+@ExtendWith(MockitoExtension::class)
+class CachedFeatureFlagUpdateTaskTest {
+
+    companion object {
+        private val OBJECT_MAPPER = ObjectMapperBuilder.build()
+    }
+
+    @InjectMocks
+    private lateinit var cachedFeatureFlagManager: CachedFeatureFlagManager
+
+    @Spy
+    private val awsAppConfigClientOptions = AwsAppConfigClientOptions.builder()
+        .applicationName("app")
+        .environmentName("env")
+        .profile("profile")
+        .awsAppConfigProxyConfig(
+            AwsAppConfigDataClientProxyConfig.builder()
+                .region(Region.AP_NORTHEAST_1)
+                .pollingDelay(Duration.ZERO)
+                .build(),
+        )
+        .build()
+
+    @Mock
+    private lateinit var appConfigDataClient: AppConfigDataClient
+
+    @Mock
+    private lateinit var scheduledTaskExecutor: ScheduledTaskExecutor
+
+    private lateinit var cachedFeatureFlagUpdateTask: CachedFeatureFlagUpdateTask
+
+    @BeforeEach
+    fun setup() {
+        cachedFeatureFlagUpdateTask = cachedFeatureFlagManager.CachedFeatureFlagUpdateTask()
+    }
+
+    @Nested
+    inner class NewCache {
+
+        @Test
+        fun normal() {
+            // prepare
+            val oldCache = FeatureFlagCache.builder()
+                .token(
+                    Credential.builder()
+                        .rawValue("token")
+                        .build(),
+                )
+                .flags(emptyMap())
+                .build()
+            val flag = // language=json
+                """
+                  {
+                    "a": {
+                      "enabled": false,
+                      "flag_value": 1
+                    },
+                    "b": {
+                      "enabled": true,
+                      "flag_value": "abc"
+                    }
+                  }
+                """.trimIndent()
+            val sdkBytes = mock<SdkBytes> {
+                on { asUtf8String() } doReturn flag
+            }
+            val response = mock<GetLatestConfigurationResponse> {
+                on { nextPollConfigurationToken() } doReturn "newToken"
+                on { configuration() } doReturn sdkBytes
+            }
+            val expected = FeatureFlagCache.builder()
+                .token(
+                    Credential.builder()
+                        .rawValue("newToken")
+                        .build(),
+                )
+                .flags(
+                    mapOf(
+                        "a" to OBJECT_MAPPER.createObjectNode().apply {
+                            put("enabled", false)
+                            put("flag_value", 1)
+                        },
+                        "b" to OBJECT_MAPPER.createObjectNode().apply {
+                            put("enabled", true)
+                            put("flag_value", "abc")
+                        },
+                    ),
+                )
+                .build()
+
+            // do & verify
+            assertThat(
+                cachedFeatureFlagUpdateTask.newCache(
+                    /* oldCache = */ oldCache,
+                    /* response = */ response,
+                ),
+            ).isEqualTo(expected)
+        }
+
+        @Test
+        fun `response is empty`() {
+            // prepare
+            val oldCache = FeatureFlagCache.builder()
+                .token(
+                    Credential.builder()
+                        .rawValue("token")
+                        .build(),
+                )
+                .flags(
+                    mapOf(
+                        "a" to OBJECT_MAPPER.createObjectNode().apply {
+                            put("enabled", false)
+                            put("flag_value", 1)
+                        },
+                    ),
+                )
+                .build()
+            val flag = ""
+            val sdkBytes = mock<SdkBytes> {
+                on { asUtf8String() } doReturn flag
+            }
+            val response = mock<GetLatestConfigurationResponse> {
+                on { nextPollConfigurationToken() } doReturn "newToken"
+                on { configuration() } doReturn sdkBytes
+            }
+            val expected = FeatureFlagCache.builder()
+                .token(
+                    // updated
+                    Credential.builder()
+                        .rawValue("newToken")
+                        .build(),
+                )
+                .flags(
+                    // not updated
+                    mapOf(
+                        "a" to OBJECT_MAPPER.createObjectNode().apply {
+                            put("enabled", false)
+                            put("flag_value", 1)
+                        },
+                    ),
+                )
+                .build()
+
+            // do & verify
+            assertThat(
+                cachedFeatureFlagUpdateTask.newCache(
+                    /* oldCache = */ oldCache,
+                    /* response = */ response,
+                ),
+            ).isEqualTo(expected)
+        }
+
+        @Test
+        fun `unparsable response`() {
+            // prepare
+            val oldCache = FeatureFlagCache.builder()
+                .token(
+                    Credential.builder()
+                        .rawValue("token")
+                        .build(),
+                )
+                .flags(
+                    mapOf(
+                        "a" to OBJECT_MAPPER.createObjectNode().apply {
+                            put("enabled", false)
+                            put("flag_value", 1)
+                        },
+                    ),
+                )
+                .build()
+            val flag = """invalid json"""
+            val sdkBytes = mock<SdkBytes> {
+                on { asUtf8String() } doReturn flag
+            }
+            val response = mock<GetLatestConfigurationResponse> {
+                on { nextPollConfigurationToken() } doReturn "newToken"
+                on { configuration() } doReturn sdkBytes
+            }
+            val expected = FeatureFlagCache.builder()
+                .token(
+                    // updated
+                    Credential.builder()
+                        .rawValue("newToken")
+                        .build(),
+                )
+                .flags(
+                    // not updated
+                    mapOf(
+                        "a" to OBJECT_MAPPER.createObjectNode().apply {
+                            put("enabled", false)
+                            put("flag_value", 1)
+                        },
+                    ),
+                )
+                .build()
+
+            // do & verify
+            assertThat(
+                cachedFeatureFlagUpdateTask.newCache(
+                    /* oldCache = */ oldCache,
+                    /* response = */ response,
+                ),
+            ).isEqualTo(expected)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ aws-bom = { module = "software.amazon.awssdk:bom", version.ref = "aws-sdk" }
 aws-appconfigdata = { module = "software.amazon.awssdk:appconfigdata" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.1.0" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
 log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version = "2.23.1" }
 openfeature = { module = "dev.openfeature:sdk", version.ref = "openfeature" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version = "2.0.13" }


### PR DESCRIPTION
# What

Add new support for `AppConfigDataClient`.

closes #51.

# How

AppConfig access costs money. So, I choose the way keeps the feature flags in local cache, not to request to it every flag evaluation.

## `CachedFeatureFlagManager`

The core of local caching is `CachedFeatureFlagManager`.

This manages following things.

- local feature flags cache
- session for AWS AppConfig
- safe close of the resource (thread, connection to AWS AppConfig)

Also, an infastructure for executing infinite task is introduced.
This is `ScheduledTaskExecutor`.

## Using this feature

Application Author who is using this provider implementatin can use this feature by configuring `AwsAppConfigDataClientProxyConfig`.
This proxy config is for using `AwsAppConfigDataClientProxy`, which proxys the feature flag request to AWS AppConfig through `AppConfigDataClient`.

e.g.

```java
// provider configuration
AwsAppConfigClientOptions options = AwsAppConfigClientOptions.builder()
        .applicationName("AWS AppConfig application name")
        .environmentName("AWS AppConfig environment name")
        .profile("AWS AppConfig profile name")
        .awsAppConfigProxyConfig(
            // access AWS AppConfig via using `AppConfigDataClient`.
            AwsAppConfigDataClientProxyConfig.builder()
                // your aws region
                .region(Region.AP_NORTHEAST_1)
                // feature flags polling duration. this will affect AWS cost
                .pollingDelay(Duration.ZERO)
                .build()
        )
        .build();

// configure a provider
AwsAppConfigFeatureProvider provider = new AwsAppConfigFeatureProvider(options);
```

docs. https://sdk.amazonaws.com/java/api/2.25.45/software/amazon/awssdk/services/appconfigdata/AppConfigDataClient.html

# Notes

Supporting use of `AppConfigDataClient` instance application author instantinated will be in the future.
