### PR TITLE
Close resource and update provider status

### DIFF
--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/AwsAppConfigClientService.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/AwsAppConfigClientService.java
@@ -20,6 +20,7 @@ import io.github.lavenderses.aws_app_config_openfeature_provider.parser.ObjectAt
 import io.github.lavenderses.aws_app_config_openfeature_provider.parser.StringAttributeParser;
 import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.AwsAppConfigProxy;
 import io.github.lavenderses.aws_app_config_openfeature_provider.proxy.AwsAppConfigProxyBuilder;
+import jakarta.annotation.PostConstruct;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,7 +35,7 @@ import java.util.function.Function;
 /**
  * Service layer class for AWS AppConfig.
  */
-final class AwsAppConfigClientService {
+final class AwsAppConfigClientService implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(AwsAppConfigClientService.class);
 
@@ -112,6 +113,20 @@ final class AwsAppConfigClientService {
         integerAttributeParser = new IntegerAttributeParser();
         doubleAttributeParser = new DoubleAttributeParser();
         objectAttributeParser = new ObjectAttributeParser();
+    }
+
+    @Override
+    public void close() throws Exception {
+        appConfigState.set(AwsAppConfigState.SHUTTING_DOWN);
+
+        awsAppConfigProxy.close();
+
+        appConfigState.set(AwsAppConfigState.SHUT_DOWNED);
+    }
+
+    void initialize() {
+        appConfigState.set(AwsAppConfigState.PREPARING);
+        appConfigState.set(AwsAppConfigState.READY);
     }
 
     @NotNull

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/exception/AwsAppConfigProviderException.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/exception/AwsAppConfigProviderException.java
@@ -1,0 +1,14 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.exception;
+
+import org.jetbrains.annotations.Nullable;
+
+public class AwsAppConfigProviderException extends RuntimeException {
+
+    public AwsAppConfigProviderException(@Nullable final String message, @Nullable final Exception e) {
+        super(message, e);
+    }
+    
+    public AwsAppConfigProviderException(@Nullable final String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/exception/ProviderCloseException.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/exception/ProviderCloseException.java
@@ -1,0 +1,14 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.exception;
+
+import org.jetbrains.annotations.Nullable;
+
+public final class ProviderCloseException extends AwsAppConfigProviderException {
+
+    public ProviderCloseException(@Nullable final String message, @Nullable final Exception e) {
+        super(message, e);
+    }
+
+    public ProviderCloseException(@Nullable final String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/exception/ScheduledTaskExecutorCloseException.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/exception/ScheduledTaskExecutorCloseException.java
@@ -1,0 +1,14 @@
+package io.github.lavenderses.aws_app_config_openfeature_provider.exception;
+
+import org.jetbrains.annotations.Nullable;
+
+public class ScheduledTaskExecutorCloseException extends AwsAppConfigProviderException {
+
+    public ScheduledTaskExecutorCloseException(@Nullable final String message, @Nullable final Exception e) {
+        super(message, e);
+    }
+
+    public ScheduledTaskExecutorCloseException(@Nullable final String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagManager.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/proxy/appconfig_data_client/CachedFeatureFlagManager.java
@@ -195,6 +195,7 @@ final class CachedFeatureFlagManager implements AutoCloseable {
         scheduledTaskExecutor = new ScheduledTaskExecutor(
             /* option = */ ScheduledTaskOption.builder()
                 .delay(config.getPollingDelay())
+                .taskName("cachedFeatureFlagUpdateTask")
                 .build()
         );
     }

--- a/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTaskOption.java
+++ b/core/src/main/java/io/github/lavenderses/aws_app_config_openfeature_provider/task/ScheduledTaskOption.java
@@ -20,6 +20,10 @@ public final class ScheduledTaskOption {
         .delay(Duration.ZERO)
         .build();
 
+    @NotNull
+    @NonNull
+    private final String taskName;
+
     /**
      * Fixed delay of the task({@link ScheduledTask}) interval.
      */


### PR DESCRIPTION
# What

Add
- Provider status transition
- appropreate resource closing

close #48.

# How

## clients

By implementing `AutoClosable`.
Implemented `close` to close clients and its properties. And also status transition is also implemented in it.

`AwsAppConfigAgentProxy` is just containing HTTP client instance. So nothing is done on close method.

## thread

Terminate and log it in `ScheduledTaskExecutor#close`.
This task manager tries one retry of Executor termination. If it gave up, throws an exception.

# Notes

N/A
