### PR TITLE
Move Kotlin plugin applying from BasePlugin to KotlinPlugin

### DIFF
--- a/build-logic/src/main/kotlin/io/github/lavenderses/aws_appconfig_openfeature_provider/plugin/BasePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/lavenderses/aws_appconfig_openfeature_provider/plugin/BasePlugin.kt
@@ -6,7 +6,6 @@ import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.JavaTestFixturesPlugin
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 class BasePlugin : Plugin<Project> {
 
@@ -19,7 +18,6 @@ class BasePlugin : Plugin<Project> {
                 // third party
                 apply(JavaLibraryPlugin::class.java)
                 apply(JavaTestFixturesPlugin::class.java)
-                apply(libs.findPlugin("kotlin-jvm").get().get().pluginId)
             }
 
             group = projectGroupId
@@ -32,12 +30,6 @@ class BasePlugin : Plugin<Project> {
             with(extensions.getByType<JavaPluginExtension>()) {
                 sourceCompatibility = PROJECT_JDK.javaVersion
                 targetCompatibility = PROJECT_JDK.javaVersion
-            }
-
-            with(extensions.getByType<KotlinJvmProjectExtension>()) {
-                compilerOptions {
-                    this.jvmTarget.set(PROJECT_JDK.jvmTarget)
-                }
             }
 
             with(dependencies) {

--- a/build-logic/src/main/kotlin/io/github/lavenderses/aws_appconfig_openfeature_provider/plugin/KotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/lavenderses/aws_appconfig_openfeature_provider/plugin/KotlinPlugin.kt
@@ -2,6 +2,8 @@ package io.github.lavenderses.aws_appconfig_openfeature_provider.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 class KotlinPlugin: Plugin<Project> {
 
@@ -11,6 +13,13 @@ class KotlinPlugin: Plugin<Project> {
                 // first party plugin
                 apply(BasePlugin::class.java)
                 apply(KotlinLintPlugin::class.java)
+                apply(libs.findPlugin("kotlin-jvm").get().get().pluginId)
+            }
+
+            with(extensions.getByType<KotlinJvmProjectExtension>()) {
+                compilerOptions {
+                    this.jvmTarget.set(PROJECT_JDK.jvmTarget)
+                }
             }
 
             with(dependencies) {


### PR DESCRIPTION
# What

Re-removal of Kotlin dependencies from `:core` module.

close #36. relates #61.

# How

by oving Kotlin plugin applying from BasePlugin to KotlinPlugin.

I thought this is resoleved in #61, but it remained because kotlin-jvm plugin still had been applied.

# Notes

confirmed it.
![Screenshot from 2024-06-08 18-52-32](https://github.com/lavenderses/aws-appconfig-openfeature-provider-java/assets/72122101/26c0381d-eb06-4746-8063-0c62624c6428)

