### PR TITLE
Remove kotlinSourceJar task dependencies on publication task

### DIFF
--- a/build-logic/src/main/kotlin/io/github/lavenderses/aws_appconfig_openfeature_provider/plugin/PublicationPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/lavenderses/aws_appconfig_openfeature_provider/plugin/PublicationPlugin.kt
@@ -51,8 +51,7 @@ class PublicationPlugin: Plugin<Project> {
             }
 
             tasks.withType<GenerateModuleMetadata> {
-                // TODO: Remove kotlinSourcesJar
-                dependsOn("kotlinSourcesJar", "plainJavadocJar")
+                dependsOn("plainJavadocJar")
             }
         }
     }


### PR DESCRIPTION
# What

An additional operation related to.
- https://github.com/lavenderses/aws-appconfig-openfeature-provider-java/pull/67

# Why

Because publication task depends on `kotlinSourcesJar` (this is because `:core` had deps to Kotlin), publication GitHub Actions failed (https://github.com/lavenderses/aws-appconfig-openfeature-provider-java/actions/runs/12853227488/job/35836140265).

# How

Remove task deps to `kotlinSourcesJar`.

# Notes

N/A